### PR TITLE
Refactor tooltip appearance

### DIFF
--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMelee.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMelee.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { afterUpdate } from 'svelte';
   import { onAfterUpdate } from './tooltip-helpers';
-  import { estimatedMeleeAttackDamage } from '../play/utils';
+  import { distanceBetweenPoints, estimatedMeleeAttackDamage, MELEE_ATTACK_RANGE } from '../play/utils';
   import HoveredGamePieceTooltipUnitCard from './HoveredGamePieceTooltipUnitCard.svelte';
 
   export let game: Game;
@@ -39,56 +39,61 @@
             <div class="text-center">Friendly unit</div>
           {/if}
         {:else}
-          {@const selectedUnit = selectedPiece.playerUnit.unit}
-          {@const estDamage = estimatedMeleeAttackDamage(selectedUnit, hoveredUnit)}
-          {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
+          {@const attackDistance = distanceBetweenPoints(selectedPiece.coordinates, hoveredPiece.coordinates)}
+          {#if attackDistance > MELEE_ATTACK_RANGE}
+            <div class="text-center">Target out of range</div>
+          {:else}
+            {@const selectedUnit = selectedPiece.playerUnit.unit}
+            {@const estDamage = estimatedMeleeAttackDamage(selectedUnit, hoveredUnit)}
+            {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
 
-          <div class="grid grid-cols-3 gap-4mx-auto">
-            <div class="col-span-2 border-r border-black p-[8px]">
-              <div class="text-center">
-                {selectedPiece.playerUnit.name} 
-                <i class="fa-solid fa-sword"></i> 
-                {hoveredPiece.playerUnit.name}
+            <div class="grid grid-cols-3 gap-4mx-auto">
+              <div class="col-span-2 border-r border-black p-[8px]">
+                <div class="text-center">
+                  {selectedPiece.playerUnit.name} 
+                  <i class="fa-solid fa-sword"></i> 
+                  {hoveredPiece.playerUnit.name}
+                </div>
+      
+                <table class="mx-auto mt-[5px]">
+                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                    <th></th>
+                    <th><i class="fa-solid fa-hashtag"></i></th>
+                    <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+                    <th><i class="fa-solid fa-hand-fist"></i></th>
+                    <th><i class="fa-solid fa-shield-slash"></i></th>
+                    <th><i class="fa-solid fa-heart-crack"></i></th>
+                  </tr>
+                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                    <td><i class="fa-solid fa-sword"></i></td>
+                    <td>{selectedUnit.meleeNumAttacks}</td>
+                    <td>{selectedUnit.meleeHitRoll}+</td>
+                    <td>{selectedUnit.meleeWoundRoll}+</td>
+                    <td>{selectedUnit.meleeArmorPiercing}</td>
+                    <td>{selectedUnit.meleeDamage}</td>
+                  </tr>
+                </table>
               </div>
-    
-              <table class="mx-auto mt-[5px]">
-                <tr class="[&>*]:px-[4px] [&>*]:text-center">
-                  <th></th>
-                  <th><i class="fa-solid fa-hashtag"></i></th>
-                  <th><i class="fa-solid fa-bullseye-arrow"></i></th>
-                  <th><i class="fa-solid fa-hand-fist"></i></th>
-                  <th><i class="fa-solid fa-shield-slash"></i></th>
-                  <th><i class="fa-solid fa-heart-crack"></i></th>
-                </tr>
-                <tr class="[&>*]:px-[4px] [&>*]:text-center">
-                  <td><i class="fa-solid fa-sword"></i></td>
-                  <td>{selectedUnit.meleeNumAttacks}</td>
-                  <td>{selectedUnit.meleeHitRoll}+</td>
-                  <td>{selectedUnit.meleeWoundRoll}+</td>
-                  <td>{selectedUnit.meleeArmorPiercing}</td>
-                  <td>{selectedUnit.meleeDamage}</td>
-                </tr>
-              </table>
+              <div class="col-span-1 p-[8px]">
+                <div class="text-center mt-[5px]">
+                  <i class="fa-solid fa-calculator mr-[5px]"></i>
+                  <span class="text-xl">{estDamage}</span>
+                  <span class="text-sm"> dmg</span>
+                </div>
+                <div class="text-center mt-[2px]">
+                  <i class="fa-solid fa-heart-crack mr-[5px]"></i>
+                  <span class="text-lg">{hoveredPiece.health}</span>
+                  <i class="fa-solid fa-arrow-right fa-sm"></i>
+                  {#if estHealthAfter > 0}
+                    <span class="text-lg">{estHealthAfter}</span>
+                  {:else}
+                    <i class="fa-solid fa-skull"></i>
+                  {/if}
+                </div>
+                <div class="text-center mt-[10px]">Attack?</div>
+              </div>
             </div>
-            <div class="col-span-1 p-[8px]">
-              <div class="text-center mt-[5px]">
-                <i class="fa-solid fa-calculator mr-[5px]"></i>
-                <span class="text-xl">{estDamage}</span>
-                <span class="text-sm"> dmg</span>
-              </div>
-              <div class="text-center mt-[2px]">
-                <i class="fa-solid fa-heart-crack mr-[5px]"></i>
-                <span class="text-lg">{hoveredPiece.health}</span>
-                <i class="fa-solid fa-arrow-right fa-sm"></i>
-                {#if estHealthAfter > 0}
-                  <span class="text-lg">{estHealthAfter}</span>
-                {:else}
-                  <i class="fa-solid fa-skull"></i>
-                {/if}
-              </div>
-              <div class="text-center mt-[10px]">Attack?</div>
-            </div>
-          </div>
+          {/if}
         {/if}
       </div>
     {/if}

--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMelee.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMelee.svelte
@@ -2,6 +2,7 @@
   import { afterUpdate } from 'svelte';
   import { onAfterUpdate } from './tooltip-helpers';
   import { estimatedMeleeAttackDamage } from '../play/utils';
+  import HoveredGamePieceTooltipUnitCard from './HoveredGamePieceTooltipUnitCard.svelte';
 
   export let game: Game;
   export let hoveredPiece: GamePiece | undefined;
@@ -27,31 +28,69 @@
     {@const owner = hoveredPiece.gamePlayer.player.minaPublicKey}
     {@const hoveredUnit = hoveredPiece.playerUnit.unit}
 
-    <div>{hoveredPiece.playerUnit.name} ({hoveredUnit.name})</div>
-    <div>HP: {hoveredPiece.health}/{hoveredUnit.maxHealth}</div>
+    <HoveredGamePieceTooltipUnitCard {hoveredPiece} />
 
-    {#if owner === currentPlayerMinaPubKey}
-      {#if selectedPiece && selectedPiece.id !== hoveredPiece.id}
-        <div>Friendly unit</div>
-      {:else}
-        <div># Attacks: {hoveredUnit.meleeNumAttacks}</div>
-        <div>To Hit: {hoveredUnit.meleeHitRoll}+</div>
-        <div>To Wound: {hoveredUnit.meleeWoundRoll}+</div>
-      {/if}
-    {:else}
-      {#if selectedPiece}
-        {@const selectedUnit = selectedPiece.playerUnit.unit}
-        {@const armorPiercing = selectedUnit.meleeArmorPiercing || 0}
-        {@const modifiedSave = hoveredUnit.armorSaveRoll + armorPiercing}
-        <div># Attacks: {selectedUnit.meleeNumAttacks}</div>
-        <div>To Hit: {selectedUnit.meleeHitRoll}+</div>
-        <div>To Wound: {selectedUnit.meleeWoundRoll}+</div>
-        <div>Armor Save: {modifiedSave}+ ({hoveredUnit.armorSaveRoll}+, AP-{armorPiercing})</div>
-        <div>Dmg / Attack: {selectedUnit.meleeDamage}</div>
-        <div>Est Damage: {estimatedMeleeAttackDamage(selectedUnit, hoveredUnit)}</div>
-      {:else}
-        <div>Armor: {hoveredUnit.armorSaveRoll}+</div>
-      {/if}      
+    {#if selectedPiece}
+      <div class="border-t border-black">
+        {#if owner === currentPlayerMinaPubKey}
+          {#if selectedPiece.id === hoveredPiece.id}
+            <div class="text-center">Selected unit</div>
+          {:else}
+            <div class="text-center">Friendly unit</div>
+          {/if}
+        {:else}
+          {@const selectedUnit = selectedPiece.playerUnit.unit}
+          {@const estDamage = estimatedMeleeAttackDamage(selectedUnit, hoveredUnit)}
+          {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
+
+          <div class="grid grid-cols-3 gap-4mx-auto">
+            <div class="col-span-2 border-r border-black p-[8px]">
+              <div class="text-center">
+                {selectedPiece.playerUnit.name} 
+                <i class="fa-solid fa-sword"></i> 
+                {hoveredPiece.playerUnit.name}
+              </div>
+    
+              <table class="mx-auto mt-[5px]">
+                <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                  <th></th>
+                  <th><i class="fa-solid fa-hashtag"></i></th>
+                  <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+                  <th><i class="fa-solid fa-hand-fist"></i></th>
+                  <th><i class="fa-solid fa-shield-slash"></i></th>
+                  <th><i class="fa-solid fa-heart-crack"></i></th>
+                </tr>
+                <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                  <td><i class="fa-solid fa-sword"></i></td>
+                  <td>{selectedUnit.meleeNumAttacks}</td>
+                  <td>{selectedUnit.meleeHitRoll}+</td>
+                  <td>{selectedUnit.meleeWoundRoll}+</td>
+                  <td>{selectedUnit.meleeArmorPiercing}</td>
+                  <td>{selectedUnit.meleeDamage}</td>
+                </tr>
+              </table>
+            </div>
+            <div class="col-span-1 p-[8px]">
+              <div class="text-center mt-[5px]">
+                <i class="fa-solid fa-calculator mr-[5px]"></i>
+                <span class="text-xl">{estDamage}</span>
+                <span class="text-sm"> dmg</span>
+              </div>
+              <div class="text-center mt-[2px]">
+                <i class="fa-solid fa-heart-crack mr-[5px]"></i>
+                <span class="text-lg">{hoveredPiece.health}</span>
+                <i class="fa-solid fa-arrow-right fa-sm"></i>
+                {#if estHealthAfter > 0}
+                  <span class="text-lg">{estHealthAfter}</span>
+                {:else}
+                  <i class="fa-solid fa-skull"></i>
+                {/if}
+              </div>
+              <div class="text-center mt-[10px]">Attack?</div>
+            </div>
+          </div>
+        {/if}
+      </div>
     {/if}
   {/if}
 </span>

--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMovement.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipMovement.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { afterUpdate, onMount } from 'svelte';
-  import * as Utils from '../play/utils';
+  import { afterUpdate } from 'svelte';
+  import { onAfterUpdate } from './tooltip-helpers';
+	import HoveredGamePieceTooltipUnitCard from './HoveredGamePieceTooltipUnitCard.svelte';
 
   export let hoveredPiece: GamePiece | undefined;
   export let tooltipAbsolutePosition: Point | undefined;
@@ -8,45 +9,17 @@
   export let playerColors: Array<string>;
 
   afterUpdate(() => {
-    if (hoveredPiece) {
-      showHoveredPieceTooltip();
-    } else {
-      hideHoveredPieceTooltip();
-    }
+    onAfterUpdate(
+      playerPublicKeys,
+      playerColors,
+      hoveredPiece,
+      tooltipAbsolutePosition,
+    );
   });
-
-  // const showHoveredPieceTooltip = (absolutePoint: Point, hoveredPiece: GamePiece) => {
-  const showHoveredPieceTooltip = () => {
-    var tooltip = document.querySelector('#piece-hover-tooltip') as HTMLElement;
-    if (!tooltip || !hoveredPiece || !tooltipAbsolutePosition) return;
-
-    const playerMinaPublicKey = hoveredPiece.gamePlayer.player.minaPublicKey;
-    const playerColor = Utils.playerColor(playerPublicKeys, playerMinaPublicKey, playerColors);
-    
-    tooltip.style.left = (tooltipAbsolutePosition.x + 20) + 'px';
-    tooltip.style.top = (tooltipAbsolutePosition.y + 20) + 'px';
-    tooltip.style.display = 'block';
-    tooltip.style.backgroundColor = playerColor;
-  }
-
-  const hideHoveredPieceTooltip = () => {
-    var tooltip = document.querySelector('#piece-hover-tooltip') as HTMLElement;
-    if (!tooltip) return;
-    
-    tooltip.style.display = 'none';
-  }
-
 </script>
 
 <span id="piece-hover-tooltip" class="p-2 hidden fixed overflow-hidden border border-solid border-black rounded">
   {#if hoveredPiece}
-    {@const hoveredUnit = hoveredPiece.playerUnit.unit}
-    <div>{hoveredPiece.playerUnit.name} ({hoveredUnit.name})</div>
-    <div>HP: {hoveredPiece.health}/{hoveredUnit.maxHealth}</div>
-    <div>Speed: {hoveredUnit.movementSpeed}</div>
-    <div>Armor: {hoveredUnit.armorSaveRoll}+</div>
-    {#if hoveredUnit.rangedNumAttacks}
-      <div>Missile Range: {hoveredUnit.rangedRange}</div>
-    {/if}
+    <HoveredGamePieceTooltipUnitCard {hoveredPiece} />
   {/if}
 </span>

--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipShooting.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipShooting.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { afterUpdate } from 'svelte';
   import { onAfterUpdate } from './tooltip-helpers';
-  import { estimatedRangedAttackDamage } from '../play/utils';
+  import { distanceBetweenPoints, estimatedRangedAttackDamage } from '../play/utils';
   import HoveredGamePieceTooltipUnitCard from './HoveredGamePieceTooltipUnitCard.svelte';
 
   export let game: Game;
@@ -42,58 +42,63 @@
           {/if}
         {:else}
           {@const selectedUnit = selectedPiece.playerUnit.unit}
-          {@const estDamage = estimatedRangedAttackDamage(selectedUnit, hoveredUnit)}
-          {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
+          {@const attackDistance = distanceBetweenPoints(selectedPiece.coordinates, hoveredPiece.coordinates)}
 
-          {#if selectedUnit.rangedNumAttacks}
-            <div class="grid grid-cols-3 gap-4mx-auto">
-              <div class="col-span-2 border-r border-black p-[8px]">
-                <div class="text-center">
-                  {selectedPiece.playerUnit.name} 
-                  <i class="fa-solid fa-bow-arrow"></i> 
-                  {hoveredPiece.playerUnit.name}
-                </div>
-      
-                <table class="mx-auto mt-[5px]">
-                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
-                    <th></th>
-                    <th><i class="fa-solid fa-hashtag"></i></th>
-                    <th><i class="fa-solid fa-bullseye-arrow"></i></th>
-                    <th><i class="fa-solid fa-hand-fist"></i></th>
-                    <th><i class="fa-solid fa-shield-slash"></i></th>
-                    <th><i class="fa-solid fa-heart-crack"></i></th>
-                  </tr>
-                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
-                    <td><i class="fa-solid fa-sword"></i></td>
-                    <td>{selectedUnit.rangedNumAttacks}</td>
-                    <td>{selectedUnit.rangedHitRoll}+</td>
-                    <td>{selectedUnit.rangedWoundRoll}+</td>
-                    <td>{selectedUnit.rangedArmorPiercing}</td>
-                    <td>{selectedUnit.rangedDamage}</td>
-                  </tr>
-                </table>
-              </div>
-              <div class="col-span-1 p-[8px]">
-                <div class="text-center mt-[5px]">
-                  <i class="fa-solid fa-calculator mr-[5px]"></i>
-                  <span class="text-xl">{estDamage}</span>
-                  <span class="text-sm"> dmg</span>
-                </div>
-                <div class="text-center mt-[2px]">
-                  <i class="fa-solid fa-heart-crack mr-[5px]"></i>
-                  <span class="text-lg">{hoveredPiece.health}</span>
-                  <i class="fa-solid fa-arrow-right fa-sm"></i>
-                  {#if estHealthAfter > 0}
-                    <span class="text-lg">{estHealthAfter}</span>
-                  {:else}
-                    <i class="fa-solid fa-skull"></i>
-                  {/if}
-                </div>
-                <div class="text-center mt-[10px]">Attack?</div>
-              </div>
-            </div>
+          {#if attackDistance > (selectedUnit.rangedRange || 0)}
+            <div class="text-center">Target out of range</div>
           {:else}
-            <div class="text-center">Selected unit has no ranged attack</div>
+            {@const estDamage = estimatedRangedAttackDamage(selectedUnit, hoveredUnit)}
+            {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
+
+            {#if !selectedUnit.rangedNumAttacks}
+              <div class="text-center">Selected unit has no ranged attack</div>
+            {:else}
+              <div class="grid grid-cols-3 gap-4mx-auto">
+                <div class="col-span-2 border-r border-black p-[8px]">
+                  <div class="text-center">
+                    {selectedPiece.playerUnit.name} 
+                    <i class="fa-solid fa-bow-arrow"></i> 
+                    {hoveredPiece.playerUnit.name}
+                  </div>
+                  <table class="mx-auto mt-[5px]">
+                    <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                      <th></th>
+                      <th><i class="fa-solid fa-hashtag"></i></th>
+                      <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+                      <th><i class="fa-solid fa-hand-fist"></i></th>
+                      <th><i class="fa-solid fa-shield-slash"></i></th>
+                      <th><i class="fa-solid fa-heart-crack"></i></th>
+                    </tr>
+                    <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                      <td><i class="fa-solid fa-sword"></i></td>
+                      <td>{selectedUnit.rangedNumAttacks}</td>
+                      <td>{selectedUnit.rangedHitRoll}+</td>
+                      <td>{selectedUnit.rangedWoundRoll}+</td>
+                      <td>{selectedUnit.rangedArmorPiercing}</td>
+                      <td>{selectedUnit.rangedDamage}</td>
+                    </tr>
+                  </table>
+                </div>
+                <div class="col-span-1 p-[8px]">
+                  <div class="text-center mt-[5px]">
+                    <i class="fa-solid fa-calculator mr-[5px]"></i>
+                    <span class="text-xl">{estDamage}</span>
+                    <span class="text-sm"> dmg</span>
+                  </div>
+                  <div class="text-center mt-[2px]">
+                    <i class="fa-solid fa-heart-crack mr-[5px]"></i>
+                    <span class="text-lg">{hoveredPiece.health}</span>
+                    <i class="fa-solid fa-arrow-right fa-sm"></i>
+                    {#if estHealthAfter > 0}
+                      <span class="text-lg">{estHealthAfter}</span>
+                    {:else}
+                      <i class="fa-solid fa-skull"></i>
+                    {/if}
+                  </div>
+                  <div class="text-center mt-[10px]">Attack?</div>
+                </div>
+              </div>
+            {/if}
           {/if}
         {/if}
       </div>

--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipShooting.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipShooting.svelte
@@ -4,6 +4,7 @@
   import { afterUpdate } from 'svelte';
   import { onAfterUpdate } from './tooltip-helpers';
   import { estimatedRangedAttackDamage } from '../play/utils';
+  import HoveredGamePieceTooltipUnitCard from './HoveredGamePieceTooltipUnitCard.svelte';
 
   export let game: Game;
   export let hoveredPiece: GamePiece | undefined;
@@ -29,39 +30,73 @@
     {@const owner = hoveredPiece.gamePlayer.player.minaPublicKey}
     {@const hoveredUnit = hoveredPiece.playerUnit.unit}
 
-    <div>{hoveredPiece.playerUnit.name} ({hoveredUnit.name})</div>
-    <div>HP: {hoveredPiece.health}/{hoveredUnit.maxHealth}</div>
+    <HoveredGamePieceTooltipUnitCard {hoveredPiece} />
 
-    {#if owner === currentPlayerMinaPubKey}
-      {#if selectedPiece && selectedPiece.id !== hoveredPiece.id}
-        <div>Friendly unit</div>
-      {:else}
-        {#if hoveredUnit.rangedNumAttacks}
-          <div># Attacks: {hoveredUnit.rangedNumAttacks}</div>
-          <div>To Hit: {hoveredUnit.rangedHitRoll}+</div>
-          <div>To Wound: {hoveredUnit.rangedWoundRoll}+</div>
+    {#if selectedPiece}
+      <div class="border-t border-black">
+        {#if owner === currentPlayerMinaPubKey}
+          {#if selectedPiece.id === hoveredPiece.id}
+            <div class="text-center">Selected unit</div>
+          {:else}
+            <div class="text-center">Friendly unit</div>
+          {/if}
         {:else}
-          <div>No ranged attack</div>
+          {@const selectedUnit = selectedPiece.playerUnit.unit}
+          {@const estDamage = estimatedRangedAttackDamage(selectedUnit, hoveredUnit)}
+          {@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
+
+          {#if selectedUnit.rangedNumAttacks}
+            <div class="grid grid-cols-3 gap-4mx-auto">
+              <div class="col-span-2 border-r border-black p-[8px]">
+                <div class="text-center">
+                  {selectedPiece.playerUnit.name} 
+                  <i class="fa-solid fa-bow-arrow"></i> 
+                  {hoveredPiece.playerUnit.name}
+                </div>
+      
+                <table class="mx-auto mt-[5px]">
+                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                    <th></th>
+                    <th><i class="fa-solid fa-hashtag"></i></th>
+                    <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+                    <th><i class="fa-solid fa-hand-fist"></i></th>
+                    <th><i class="fa-solid fa-shield-slash"></i></th>
+                    <th><i class="fa-solid fa-heart-crack"></i></th>
+                  </tr>
+                  <tr class="[&>*]:px-[4px] [&>*]:text-center">
+                    <td><i class="fa-solid fa-sword"></i></td>
+                    <td>{selectedUnit.rangedNumAttacks}</td>
+                    <td>{selectedUnit.rangedHitRoll}+</td>
+                    <td>{selectedUnit.rangedWoundRoll}+</td>
+                    <td>{selectedUnit.rangedArmorPiercing}</td>
+                    <td>{selectedUnit.rangedDamage}</td>
+                  </tr>
+                </table>
+              </div>
+              <div class="col-span-1 p-[8px]">
+                <div class="text-center mt-[5px]">
+                  <i class="fa-solid fa-calculator mr-[5px]"></i>
+                  <span class="text-xl">{estDamage}</span>
+                  <span class="text-sm"> dmg</span>
+                </div>
+                <div class="text-center mt-[2px]">
+                  <i class="fa-solid fa-heart-crack mr-[5px]"></i>
+                  <span class="text-lg">{hoveredPiece.health}</span>
+                  <i class="fa-solid fa-arrow-right fa-sm"></i>
+                  {#if estHealthAfter > 0}
+                    <span class="text-lg">{estHealthAfter}</span>
+                  {:else}
+                    <i class="fa-solid fa-skull"></i>
+                  {/if}
+                </div>
+                <div class="text-center mt-[10px]">Attack?</div>
+              </div>
+            </div>
+          {:else}
+            <div class="text-center">Selected unit has no ranged attack</div>
+          {/if}
         {/if}
-      {/if}
-    {:else}
-      {#if selectedPiece}
-        {@const selectedUnit = selectedPiece.playerUnit.unit}
-        {#if selectedUnit.rangedNumAttacks}
-          {@const armorPiercing = selectedUnit.rangedArmorPiercing || 0}
-          {@const modifiedSave = hoveredUnit.armorSaveRoll + armorPiercing}
-          <div># Attacks: {selectedUnit.rangedNumAttacks}</div>
-          <div>To Hit: {selectedUnit.rangedHitRoll}+</div>
-          <div>To Wound: {selectedUnit.rangedWoundRoll}+</div>
-          <div>Armor Save: {modifiedSave}+ ({hoveredUnit.armorSaveRoll}+, AP-{armorPiercing})</div>
-          <div>Dmg / Attack: {selectedUnit.rangedDamage}</div>
-          <div>Est Damage: {estimatedRangedAttackDamage(selectedUnit, hoveredUnit)}</div>
-        {:else}
-          <div>Selected unit has no ranged attack</div>
-        {/if}
-      {:else}
-        <div>Armor: {hoveredUnit.armorSaveRoll}+</div>
-      {/if}      
+      </div>
     {/if}
   {/if}
 </span>

--- a/src/lib/components/sandbox/arena/HoveredGamePieceTooltipUnitCard.svelte
+++ b/src/lib/components/sandbox/arena/HoveredGamePieceTooltipUnitCard.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { imagePathForUnit } from '../play/utils';
+
+  export let hoveredPiece: GamePiece;
+</script>
+
+{#if hoveredPiece}
+  {@const hoveredUnit = hoveredPiece.playerUnit.unit}
+  {@const unitImagePath = imagePathForUnit(hoveredUnit)}
+  <div class="grid grid-cols-2 gap-4mx-auto">
+    <div class="col-span-1">
+      {#if unitImagePath}
+        <img alt="Unit image" src={unitImagePath} width="150" height="150" />
+      {:else}
+        No image for unit
+      {/if}
+    </div>
+    <div class="col-span-1">
+      <div class="text-center">{hoveredPiece.playerUnit.name}</div>
+      <div class="text-center">{hoveredUnit.name}</div>
+
+      <table class="mx-auto">
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <th><i class="fa-solid fa-person-running-fast"></i></th>
+          <th><i class="fa-solid fa-shield"></i></th>
+          <th><i class="fa-solid fa-heart"></i></th>
+        </tr>
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <td>{hoveredUnit.movementSpeed}</td>
+          <td>{hoveredUnit.armorSaveRoll}+</td>
+          <td>{hoveredPiece.health}/{hoveredUnit.maxHealth}</td>
+        </tr>
+      </table>
+      <table class="mx-auto mt-[5px]">
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <th></th>
+          <th><i class="fa-solid fa-hashtag"></i></th>
+          <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+          <th><i class="fa-solid fa-hand-fist"></i></th>
+          <th><i class="fa-solid fa-shield-slash"></i></th>
+          <th><i class="fa-solid fa-heart-crack"></i></th>
+        </tr>
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <td><i class="fa-solid fa-sword"></i></td>
+          <td>{hoveredUnit.meleeNumAttacks}</td>
+          <td>{hoveredUnit.meleeHitRoll}+</td>
+          <td>{hoveredUnit.meleeWoundRoll}+</td>
+          <td>{hoveredUnit.meleeArmorPiercing}</td>
+          <td>{hoveredUnit.meleeDamage}</td>
+        </tr>
+        {#if hoveredUnit.rangedNumAttacks}
+          <tr class="[&>*]:px-[4px] [&>*]:text-center">
+            <td><i class="fa-solid fa-bow-arrow"></i></td>
+            <td>{hoveredUnit.rangedNumAttacks}</td>
+            <td>{hoveredUnit.rangedHitRoll}+</td>
+            <td>{hoveredUnit.rangedWoundRoll}+</td>
+            <td>{hoveredUnit.rangedArmorPiercing}</td>
+            <td>{hoveredUnit.rangedDamage}</td>
+          </tr>
+        {/if}
+      </table>
+    </div>
+  </div>
+{/if}

--- a/src/lib/components/sandbox/play/utils.ts
+++ b/src/lib/components/sandbox/play/utils.ts
@@ -5,6 +5,17 @@ const MISSILE_RANGE_CIRCLE_STROKE_COLOR = 'lightcoral';
 const MELEE_RANGE_CIRCLE_STROKE_COLOR = '#6b0000';
 const MELEE_RANGE_CIRCLE_FILL_COLOR = '#ffb0b0';
 
+const IMAGE_PATH_BY_UNIT_NAME: Record<string, string> = {
+  'Archer': '/images/archer.png',
+  'Peasant': '/images/archer.png',
+  'Swordsman': '/images/archer.png',
+  'Spearman': '/images/archer.png',
+  'Light Cavalry': '/images/archer.png',
+  'Heavy Cavalry': '/images/archer.png',
+  'Ballista': '/images/archer.png',
+  'Hero': '/images/archer.png',
+};
+
 export const PIECE_RADIUS = 12;
 export const MELEE_ATTACK_RANGE = 50;
 
@@ -304,4 +315,12 @@ export const hexToRgb = (hex: string) => {
     g: parseInt(result[2], 16),
     b: parseInt(result[3], 16)
   } : null;
+}
+
+export const imagePathForUnit = (unit: Unit): string => {
+  return IMAGE_PATH_BY_UNIT_NAME[unit.name];
+}
+
+export const imagePathForPiece = (piece: GamePiece): string => {
+  return imagePathForUnit(piece.playerUnit.unit);
 }


### PR DESCRIPTION
Update the GamePiece hovered tooltip to show:
- The hovered unit's image
  - Right now just stubbing them all with the same image, but making it easy to map units to images
- The hovered unit's stats card
- Info on whether this is a valid proposed attack or not
- If a valid proposed attack, show the attacker's stats as well, and the estimated damage

![Screen Shot 2023-07-09 at 4 07 05 PM](https://github.com/mina-arena/mina-arena/assets/8811423/136a2d3b-b77a-49a0-8f44-77e1cc673fe2)
![Screen Shot 2023-07-09 at 4 07 14 PM](https://github.com/mina-arena/mina-arena/assets/8811423/70ab66dc-ff55-40f3-b057-cd57c528aeee)
![Screen Shot 2023-07-09 at 4 07 42 PM](https://github.com/mina-arena/mina-arena/assets/8811423/d141d1a3-644d-47b6-be74-b55dccf31b91)
![Screen Shot 2023-07-09 at 4 07 54 PM](https://github.com/mina-arena/mina-arena/assets/8811423/30af484c-f726-47ad-93ae-f54f5a63735b)
![Screen Shot 2023-07-09 at 4 08 06 PM](https://github.com/mina-arena/mina-arena/assets/8811423/84176b1e-68fc-4105-9527-1f74c4751baa)
![Screen Shot 2023-07-09 at 4 12 43 PM](https://github.com/mina-arena/mina-arena/assets/8811423/8114292f-25da-4ec2-bc78-a6acc24fe720)
