### PR TITLE
Fix loading of battlefield background image

### DIFF
--- a/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
+++ b/src/lib/components/sandbox/arena/ArenaCanvasMeleePhase.svelte
@@ -39,6 +39,8 @@
 		Utils.drawArenaBackground(ctx);
 		initDrawnPieces();
 		initGamePieceOrders();
+		Utils.loadGamePieceImages(gamePieces);
+		Utils.loadArenaBackgroundImage(onUpdate);
 	});
 
 	const initDrawnPieces = () => {
@@ -55,12 +57,14 @@
 		playerGamePieces.forEach((piece) => (orders[piece.id] = []));
 	};
 
-	afterUpdate(() => {
+	const onUpdate = () => {
 		Utils.clearCanvas(ctx);
 		Utils.drawArenaBackground(ctx);
 		drawPieces();
 		drawMeleePhase(canvas, orders, selectedPiece);
-	});
+	}
+
+	afterUpdate(onUpdate);
 
 	const drawPieces = () => {
 		Utils.drawAllPieces(canvas, ctx, drawnPieces, hoveredPiece, selectedPiece);

--- a/src/lib/components/sandbox/arena/ArenaCanvasMovementPhase.svelte
+++ b/src/lib/components/sandbox/arena/ArenaCanvasMovementPhase.svelte
@@ -38,6 +38,8 @@
     Utils.drawArenaBackground(ctx);
     initDrawnPieces();
     initGamePieceOrders();
+    Utils.loadGamePieceImages(gamePieces);
+    Utils.loadArenaBackgroundImage(onUpdate);
   });
 
   const initDrawnPieces = () => {
@@ -54,12 +56,14 @@
     playerGamePieces.forEach((piece) => orders[piece.id] = []);
   };
 
-  afterUpdate(() => {
+  const onUpdate = () => {
     Utils.clearCanvas(ctx);
     Utils.drawArenaBackground(ctx);
     drawMovementPhase(canvas, orders, selectedPiece);
     drawPieces();
-  });
+  }
+
+  afterUpdate(onUpdate);
 
   const drawPieces = () => {
     Utils.drawAllPieces(canvas, ctx, drawnPieces, hoveredPiece, selectedPiece);

--- a/src/lib/components/sandbox/arena/ArenaCanvasShootingPhase.svelte
+++ b/src/lib/components/sandbox/arena/ArenaCanvasShootingPhase.svelte
@@ -39,6 +39,8 @@
 		Utils.drawArenaBackground(ctx);
 		initDrawnPieces();
 		initGamePieceOrders();
+		Utils.loadGamePieceImages(gamePieces);
+		Utils.loadArenaBackgroundImage(onUpdate);
 	});
 
 	const initDrawnPieces = () => {
@@ -55,13 +57,15 @@
 		playerGamePieces.forEach((piece) => (orders[piece.id] = []));
 	};
 
-	afterUpdate(() => {
+	const onUpdate = () => {
 		Utils.clearCanvas(ctx);
 		Utils.drawArenaBackground(ctx);
 		drawShootingPhaseUnderPieces(canvas, orders, selectedPiece);
 		drawPieces();
 		drawShootOrders(ctx, orders);
-	});
+	}
+
+	afterUpdate(onUpdate);
 
 	const drawPieces = () => {
 		Utils.drawAllPieces(canvas, ctx, drawnPieces, hoveredPiece, selectedPiece);

--- a/src/lib/components/sandbox/play/utils.ts
+++ b/src/lib/components/sandbox/play/utils.ts
@@ -1,3 +1,5 @@
+import { imagePathForUnit } from "$lib/utils";
+
 const PIECE_STROKE_COLOR = '#101010';
 const PIECE_SELECTED_STROKE_COLOR = '#771111';
 const MISSILE_RANGE_CIRCLE_FILL_COLOR = '#ffe9f0';
@@ -7,6 +9,8 @@ const MELEE_RANGE_CIRCLE_FILL_COLOR = '#ffb0b0';
 
 export const PIECE_RADIUS = 12;
 export const MELEE_ATTACK_RANGE = 50;
+
+export const ARENA_BACKGROUND_IMAGE_PATH = '/images/battlefield_dirt_650x550.png';
 
 const ICON_BY_UNIT_NAME: Record<string, IconData> = {
   'archer': { unicode: '\uF6B9', name: 'fa-bow-arrow', xOffset: -7, yOffset: 5 },
@@ -36,6 +40,34 @@ export const drawArenaBackground = (ctx: CanvasRenderingContext2D) => {
   if (!img) return;
 
   ctx.drawImage(img, 0, 0);
+}
+
+// Load an image given its relative path.
+// Optionally also run some callback when the image is loaded.
+export const loadImage = (imagePath: string, callback?: () => void) => {
+  var img = new Image();
+  if (callback) img.onload = function() { callback() };
+  img.src = imagePath;
+}
+
+// Given an array of GamePieces, ensure the browser has loaded all
+// their images to improve image rendering speed when the tooltip is opened
+export const loadGamePieceImages = (gamePieces: GamePiece[]) => {
+  let loadedImagePaths: string[] = [];
+  gamePieces.forEach(piece => {
+    const unit = piece.playerUnit.unit;
+    if (!unit) return;
+
+    const imagePath = imagePathForUnit(unit);
+    if (loadedImagePaths.includes(imagePath)) return;
+
+    loadedImagePaths.push(imagePath);
+    loadImage(imagePath);
+  });
+}
+
+export const loadArenaBackgroundImage = (callback?: () => void) => {
+  loadImage(ARENA_BACKGROUND_IMAGE_PATH, callback);
 }
 
 export const makePiece = (piece: GamePiece, playerColor: string) => {


### PR DESCRIPTION
## Problem

Svelte is not automatically rerendering the component when the arena background image is loaded because the image is drawn on the canvas rather than declared via HTML in the svelte component itself. This results in you loading the page and seeing the following until you do something which triggers the page to rerender, such as mousing over a unit.

<img width="700" alt="Screen Shot 2023-07-16 at 8 10 31 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/78ae595b-ae42-4b29-b573-866a4ecdbdda">

## Solution

- Implement a way to manually trigger an image to be loaded, and the ability to provide a callback to run after the image is loaded.
- When creating the arena phase components, ensure they load the background image and rerender when it's loaded.

## Notes

Further, this is only an issue the first time you load/refresh the page. Subsequent phase/turn transitions all look fine because the browser has already cached the image.