### PR TITLE
Push tooltip up if mouse toward bottom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@apollo/client": "^3.7.9",
 				"graphql": "^16.6.0",
-				"mina-arena-contracts": "^0.4.1",
+				"mina-arena-contracts": "^0.4.2",
 				"snarkyjs": "^0.11.4",
 				"svelte-modals": "^1.2.1"
 			},

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"dependencies": {
 		"@apollo/client": "^3.7.9",
 		"graphql": "^16.6.0",
-		"mina-arena-contracts": "^0.4.1",
+		"mina-arena-contracts": "^0.4.2",
 		"snarkyjs": "^0.11.4",
 		"svelte-modals": "^1.2.1"
 	}

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMelee.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMelee.svelte
@@ -18,7 +18,7 @@
 	let currentPlayerMinaPubKey: string = game.currentPhase?.gamePlayer.player.minaPublicKey || '';
 
 	afterUpdate(() => {
-		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, tooltipAbsolutePosition);
+		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, selectedPiece, tooltipAbsolutePosition);
 	});
 </script>
 

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMovement.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMovement.svelte
@@ -9,7 +9,7 @@
 	export let playerColors: Array<string>;
 
 	afterUpdate(() => {
-		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, tooltipAbsolutePosition);
+		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, undefined, tooltipAbsolutePosition);
 	});
 </script>
 

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipShooting.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipShooting.svelte
@@ -14,7 +14,7 @@
 	let currentPlayerMinaPubKey: string = game.currentPhase?.gamePlayer.player.minaPublicKey || '';
 
 	afterUpdate(() => {
-		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, tooltipAbsolutePosition);
+		onAfterUpdate(playerPublicKeys, playerColors, hoveredPiece, selectedPiece, tooltipAbsolutePosition);
 	});
 </script>
 

--- a/src/lib/components/sandbox/arena/tooltip/tooltip-helpers.ts
+++ b/src/lib/components/sandbox/arena/tooltip/tooltip-helpers.ts
@@ -4,6 +4,7 @@ export const onAfterUpdate = (
   playerPublicKeys: Array<string>,
   playerColors: Array<string>,
   hoveredPiece?: GamePiece,
+  selectedPiece?: GamePiece,
   tooltipAbsolutePosition?: Point,
 ) => {
   if (hoveredPiece) {
@@ -11,6 +12,7 @@ export const onAfterUpdate = (
       playerPublicKeys,
       playerColors,
       hoveredPiece,
+      selectedPiece,
       tooltipAbsolutePosition,
     );
   } else {
@@ -22,6 +24,7 @@ export const showHoveredPieceTooltip = (
   playerPublicKeys: Array<string>,
   playerColors: Array<string>,
   hoveredPiece?: GamePiece,
+  selectedPiece?: GamePiece,
   tooltipAbsolutePosition?: Point,
 ) => {
   var tooltip = document.querySelector('#piece-hover-tooltip') as HTMLElement;
@@ -30,8 +33,21 @@ export const showHoveredPieceTooltip = (
   const playerMinaPublicKey = hoveredPiece.gamePlayer.player.minaPublicKey;
   const playerColor = Utils.playerColor(playerPublicKeys, playerMinaPublicKey, playerColors);
 
+  // If the mouse is near the bottom of the canvas,
+  // draw the tooltip above the mouse instead of below it
+  let yOffset = 0;
+  if (tooltipAbsolutePosition.y < 400) {
+    yOffset = 0;
+  } else {
+    if (selectedPiece) {
+      yOffset = -260;
+    } else {
+      yOffset = -230;
+    }
+  }
+  tooltip.style.top = (tooltipAbsolutePosition.y + 20 + yOffset) + 'px';
   tooltip.style.left = (tooltipAbsolutePosition.x + 20) + 'px';
-  tooltip.style.top = (tooltipAbsolutePosition.y + 20) + 'px';
+  
   tooltip.style.display = 'block';
   tooltip.style.backgroundColor = playerColor;
 }


### PR DESCRIPTION
If the mouse is toward the bottom of the canvas, push the tooltip up instead of down so it doesn't hang off the bottom and end up unreadable.