### PR TITLE
Fix duplicate roll submission

### DIFF
--- a/src/lib/components/sandbox/arena/arena-phases/ArenaCanvasMeleePhase.svelte
+++ b/src/lib/components/sandbox/arena/arena-phases/ArenaCanvasMeleePhase.svelte
@@ -238,19 +238,15 @@
 					const attackingPiece = Utils.gamePieceById(attackingPieceId, gamePieces);
 					const attackingUnit = attackingPiece?.playerUnit.unit;
 					const numAttacks = attackingUnit?.meleeNumAttacks || 1;
-					const diceRolls: DiceRollInput[] = [];
 					console.log(
 						`Rolling for ${numAttacks} attacks from Piece ${attackingPiece?.playerUnit.name} (ID: ${attackingPieceId})`
 					);
 					for (let i = 0; i < numAttacks; i++) {
-						const order = {
-							...meleeOrder
-						};
-						if (!order.meleeAttack) return;
+						if (!meleeOrder.meleeAttack) return;
 						const diceRoll = await rollDiceForAttack();
-						diceRolls.push(diceRoll);
-						order.meleeAttack.action.diceRolls = diceRoll;
-						meleeAttackActions.push(order.meleeAttack);
+						let attack = JSON.parse(JSON.stringify(meleeOrder.meleeAttack));
+						attack.action.diceRolls = diceRoll;
+						meleeAttackActions.push(attack);
 					}
 				})
 		);

--- a/src/lib/components/sandbox/arena/arena-phases/ArenaCanvasShootingPhase.svelte
+++ b/src/lib/components/sandbox/arena/arena-phases/ArenaCanvasShootingPhase.svelte
@@ -252,19 +252,15 @@
 					const attackingPiece = Utils.gamePieceById(attackingPieceId, gamePieces);
 					const attackingUnit = attackingPiece?.playerUnit.unit;
 					const numAttacks = attackingUnit?.rangedNumAttacks || 1;
-					const diceRolls: DiceRollInput[] = [];
 					console.log(
 						`Rolling for ${numAttacks} attacks from Piece ${attackingPiece?.playerUnit.name} (ID: ${attackingPieceId})`
 					);
 					for (let i = 0; i < numAttacks; i++) {
-						const order = {
-							...shootOrder
-						};
-						if (!order.rangedAttack) return;
+						if (!shootOrder.rangedAttack) return;
 						const diceRoll = await rollDiceForAttack();
-						diceRolls.push(diceRoll);
-						order.rangedAttack.action.diceRolls = diceRoll;
-						rangedAttackActions.push(order.rangedAttack);
+						let attack = JSON.parse(JSON.stringify(shootOrder.rangedAttack));
+						attack.action.diceRolls = diceRoll;
+						rangedAttackActions.push(attack);
 					}
 				})
 		);


### PR DESCRIPTION
Currently in prod we have this situation:
- Piece A makes 3 attacks against Piece B
- We call the dice roll service to make 3 attack roll sequences, call them Roll1, Roll2, and Roll3 (even though each contains multiple rolls)
- We then submit the attack order to the server, but we pass it [Roll3, Roll3, Roll3] instead of [Roll1, Roll2, Roll3]

This PR fixes that.

![Screen Shot 2023-07-23 at 5 48 24 PM](https://github.com/mina-arena/mina-arena/assets/8811423/14b0c191-c094-4ac2-af37-8f816f79896b)
