### PR TITLE
List my active games, allow joining

### DIFF
--- a/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
+++ b/src/lib/mina-arena-graphql-client/MinaArenaClient.ts
@@ -2,6 +2,7 @@ import { ApolloClient, HttpLink } from '@apollo/client/core/index.js';
 import { InMemoryCache } from '@apollo/client/cache/index.js';
 import { GetGameQuery } from './queries/get-game';
 import { GetGameStatusQuery } from './queries/get-game-status';
+import { GetPlayerGamesQuery } from './queries/get-player-games';
 import { GetUnitsQuery } from './queries/get-units';
 import { GetPlayerUnitsQuery } from './queries/get-player-units';
 import { CreateGameMut } from './queries/mut-create-game';
@@ -46,6 +47,16 @@ export class MinaArenaClient {
     });
 
     return data.game;
+  }
+
+  async getPlayerGames(minaPublicKey: string, statuses?: string[]): Promise<Game[]> {
+    const { data } = await this.client.query({
+      query: GetPlayerGamesQuery,
+      variables: { minaPublicKey, statuses },
+      fetchPolicy: 'no-cache',
+    });
+
+    return data.gamesForPlayer;
   }
 
   async getUnits(): Promise<Unit[]> {

--- a/src/lib/mina-arena-graphql-client/queries/get-player-games.ts
+++ b/src/lib/mina-arena-graphql-client/queries/get-player-games.ts
@@ -1,0 +1,33 @@
+import { gql } from "@apollo/client/core/index.js"
+
+export const GetPlayerGamesQuery = gql`
+  query GetPlayerGames(
+    $minaPublicKey: String!,
+    $statuses: [GameStatus!]
+  ) {
+    gamesForPlayer(
+      minaPublicKey: $minaPublicKey,
+      statuses: $statuses
+    ) {
+      id
+      status
+      turnNumber
+      currentPhase {
+        turnNumber
+        name
+        gamePlayer {
+          player {
+            minaPublicKey
+            name
+          }
+        }
+      }
+      gamePlayers {
+        player {
+          minaPublicKey
+          name
+        }
+      }
+    }
+  }
+`;

--- a/src/routes/enter/+page.svelte
+++ b/src/routes/enter/+page.svelte
@@ -1,10 +1,57 @@
+<script lang="ts">
+	import { MinaArenaClient } from "$lib/mina-arena-graphql-client/MinaArenaClient";
+	import { dummyPlayer, player1 as player1Store } from '$lib/stores/sandbox/playerStore';
+	import { onMount } from "svelte";
+	import NavItem from '$lib/components/utils/NavItem.svelte';
+	import { truncateMinaPublicKey } from "$lib/utils";
+
+	const player1 = $player1Store.publicKey;
+	const player2 = $dummyPlayer.publicKey;
+
+	const minaArenaClient = new MinaArenaClient();
+	let myGames: Game[] = [];
+	onMount(() => {
+		minaArenaClient.getPlayerGames(player1, ['IN_PROGRESS']).then((resp) => {
+			myGames = resp;
+		});
+	});
+</script>
+
 <div class="p-12">
 	<h1 class="font-almendra-bold text-4xl my-12 text-center uppercase">Choose your path</h1>
-	<div class="grid grid-cols-2 gap-20 w-3/4 border border-slate-100 mx-auto">
-		<h3 class="text-xl mb-3">Your games in progress:</h3>
-		<p>TODO</p>
-	</div>
-	<div class="w-1/4 border border-slate-300 mx-auto cursor-pointer hover:bg-slate-200">
+	{#if myGames}
+		<div class="mx-auto w-fit">
+			<p>Your games in progress:</p>
+			<table class="mx-auto border border-slate-300">
+				<tr class="[&>*]:p-2 [&>*]:text-center border-b border-slate-300">
+					<th>Your Turn?</th>
+					<th>Opponent</th>
+					<th>Turn #</th>
+					<th>Phase</th>
+					<th>Actions</th>
+				</tr>
+				{#if myGames.length > 0}
+					{#each myGames as game}
+						{@const opponents = game.gamePlayers?.filter(gp => (gp.player.minaPublicKey !== player1))}
+						<tr class="[&>*]:p-2 [&>*]:text-center border-b border-slate-300">
+							<td class="text-red-600">{game.currentPhase?.gamePlayer.player.minaPublicKey === player1 ? 'Your Turn!' : ''}</td>
+							<td>{opponents ? truncateMinaPublicKey(opponents[0].player.minaPublicKey) : ''}</td>
+							<td>{game.currentPhase?.turnNumber}</td>
+							<td>{game.currentPhase?.name}</td>
+							<td>
+								<NavItem href="/sandbox/games/{game.id}">Join</NavItem>
+							</td>
+						</tr>
+					{/each}
+				{:else}
+					<tr class="[&>*]:p-2 [&>*]:text-center border-b border-slate-300">
+						<td align="center" colspan="5">No games in progress</td>
+					</tr>
+				{/if}
+			</table>
+		</div>
+	{/if}
+	<div class="w-1/4 border border-slate-300 mx-auto mt-10 cursor-pointer hover:bg-slate-200">
 		<a href="/sandbox" class="text-center card rounded p-2">
 			<h3 class="text-xl mb-3">New Game (Sandbox)</h3>
 			<p class="text-slate-600">

--- a/src/routes/enter/+page.svelte
+++ b/src/routes/enter/+page.svelte
@@ -25,9 +25,9 @@
 			<table class="mx-auto border border-slate-300">
 				<tr class="[&>*]:p-2 [&>*]:text-center border-b border-slate-300">
 					<th>Your Turn?</th>
-					<th>Opponent</th>
-					<th>Turn #</th>
+					<th>Turn</th>
 					<th>Phase</th>
+					<th>Opponent</th>
 					<th>Actions</th>
 				</tr>
 				{#if myGames.length > 0}
@@ -35,9 +35,9 @@
 						{@const opponents = game.gamePlayers?.filter(gp => (gp.player.minaPublicKey !== player1))}
 						<tr class="[&>*]:p-2 [&>*]:text-center border-b border-slate-300">
 							<td class="text-red-600">{game.currentPhase?.gamePlayer.player.minaPublicKey === player1 ? 'Your Turn!' : ''}</td>
-							<td>{opponents ? truncateMinaPublicKey(opponents[0].player.minaPublicKey) : ''}</td>
-							<td>{game.currentPhase?.turnNumber}</td>
+							<td>Turn {game.currentPhase?.turnNumber}</td>
 							<td>{game.currentPhase?.name}</td>
+							<td>{opponents ? truncateMinaPublicKey(opponents[0].player.minaPublicKey) : ''}</td>
 							<td>
 								<NavItem href="/sandbox/games/{game.id}">Join</NavItem>
 							</td>


### PR DESCRIPTION
Prime: @45930 

## Problem

We don't currently show your active games anywhere in the app, allowing you to rejoin them.

## Solution

No games state:
![Screen Shot 2023-07-27 at 9 38 15 PM](https://github.com/mina-arena/mina-arena/assets/8811423/a66a407d-c2ed-4872-b16d-e6642a4bd26a)

Joining a game:

https://github.com/mina-arena/mina-arena/assets/8811423/8c5e3629-5567-4524-8d7b-f261ab6eddf1

## Notes

In the future we should probably also add a way to concede/resign from a game. Whether it makes sense to do that from this list or just from within the game, we can decide later. It will require a new GraphQL mutation from the server so I'm not adding it now.