### PR TITLE
Add CTA when no PlayerUnits exist yet

### DIFF
--- a/src/lib/components/sandbox/squad-selection/MyUnits.svelte
+++ b/src/lib/components/sandbox/squad-selection/MyUnits.svelte
@@ -9,6 +9,7 @@
 	export let player: string;
 
 	let selected = new Set<number>();
+	let loadingPlayerUnits = true;
 
 	const minaArenaClient = new MinaArenaClient();
 
@@ -16,6 +17,7 @@
 		try {
 			minaArenaClient.getPlayerUnits(player).then((resp) => {
 				$playerUnits[player] = resp;
+				loadingPlayerUnits = false;
 			});
 		} catch (err) {
 			$errorString = String(err);
@@ -41,19 +43,27 @@
 	};
 </script>
 
-{#if $playerUnits[player]}
-	{#if $squads && $squads[player]}
-		{#each $playerUnits[player] as playerUnit}
-			<MyUnitCard
-				{playerUnit}
-				{removeItem}
-				{addItem}
-				selected={!!$squads[player].playerUnits.find((pu) => pu.id === playerUnit.id)}
-			/>
-		{/each}
+{#if loadingPlayerUnits}
+	<i class="fa fa-solid fa-refresh fa-spin"></i> Loading...
+{:else}
+	{#if $playerUnits[player] && $playerUnits[player].length > 0}
+		{#if $squads && $squads[player]}
+			{#each $playerUnits[player] as playerUnit}
+				<MyUnitCard
+					{playerUnit}
+					{removeItem}
+					{addItem}
+					selected={!!$squads[player].playerUnits.find((pu) => pu.id === playerUnit.id)}
+				/>
+			{/each}
+		{:else}
+			{#each $playerUnits[player] as playerUnit}
+				<MyUnitCard {playerUnit} viewOnly={true} />
+			{/each}
+		{/if}
 	{:else}
-		{#each $playerUnits[player] as playerUnit}
-			<MyUnitCard {playerUnit} viewOnly={true} />
-		{/each}
+		<p class="col-span-6 mt-[40px]">
+			No custom units, draft some using the Draft Units tab.
+		</p>
 	{/if}
 {/if}

--- a/src/lib/components/sandbox/squad-selection/SquadSelection.svelte
+++ b/src/lib/components/sandbox/squad-selection/SquadSelection.svelte
@@ -45,8 +45,8 @@
 						pageSelected = 'PLAYER_UNIT';
 					}}
 			class={pageSelected === 'PLAYER_UNIT'
-						? 'border border-slate-600 rounded p-1 cursor-pointer bg-slate-100'
-						: 'border border-slate-300 rounded p-1 cursor-pointer'}
+						? 'border border-slate-600 rounded px-10 py-5 mr-5 cursor-pointer bg-slate-100'
+						: 'border border-slate-300 rounded px-10 py-5 mr-5 cursor-pointer'}
 	>
 		My Units
 	</div>
@@ -58,8 +58,8 @@
 						pageSelected = 'UNIT';
 					}}
 			class={pageSelected === 'UNIT'
-						? 'border border-slate-600 rounded p-1 cursor-pointer bg-slate-100'
-						: 'border border-slate-300 rounded p-1 cursor-pointer'}
+						? 'border border-slate-600 rounded px-10 py-5 cursor-pointer bg-slate-100'
+						: 'border border-slate-300 rounded px-10 py-5 cursor-pointer'}
 	>
 		Draft Units
 	</div>


### PR DESCRIPTION
Prime @45930 

## Problem

On the squad selection page, if you have no PlayerUnits yet, the My Units tab just shows a blank space. Also the buttons for view mode selection could be modified to match the style from the barracks page.

![Screen Shot 2023-07-29 at 1 32 39 PM](https://github.com/mina-arena/mina-arena/assets/8811423/a0ce9db3-2215-4c05-8563-259d712d10a6)

## Solution

![Screen Shot 2023-07-29 at 1 32 51 PM](https://github.com/mina-arena/mina-arena/assets/8811423/c7616ddc-7d7d-438c-aa1b-640ffc48cd04)
