### PR TITLE
Show squad points total before starting game

### DIFF
--- a/src/lib/components/sandbox/squad-selection/CompleteDraft.svelte
+++ b/src/lib/components/sandbox/squad-selection/CompleteDraft.svelte
@@ -9,6 +9,20 @@
 	const player2 = $player2Store.publicKey;
 
 	export let startGame: () => {};
+
+	const totalCost = (minaPublicKey: string) => {
+		let cost = 0;
+		
+		$squads[minaPublicKey].units.forEach((draftee) => {
+			const { unit } = draftee;
+			cost += unit.pointsCost;
+		});
+		$squads[minaPublicKey].playerUnits.forEach((playerUnit) => {
+			const { unit } = playerUnit;
+			cost += unit.pointsCost;
+		});
+		return cost;
+	};
 </script>
 
 <div>
@@ -38,6 +52,11 @@
 						<td>{playerUnit.unit.pointsCost}</td>
 					</tr>
 				{/each}
+				<tr class="[&>*]:p-2 [&>*]:bg-stone-200">
+					<td />
+					<td />
+					<td class="font-bold"><span class={totalCost(player1) > 100 ? 'text-red-400' : ''}>{totalCost(player1)}</span>/100</td>
+				</tr>
 			</table>
 		</div>
 		<div class="col-span-1">
@@ -64,6 +83,11 @@
 						<td>{playerUnit.unit.pointsCost}</td>
 					</tr>
 				{/each}
+				<tr class="[&>*]:p-2 [&>*]:bg-stone-200">
+					<td />
+					<td />
+					<td class="font-bold"><span class={totalCost(player2) > 100 ? 'text-red-400' : ''}>{totalCost(player2)}</span>/100</td>
+				</tr>
 			</table>
 		</div>
 	</div>


### PR DESCRIPTION
Prime @45930 

## Problem

After both players select their squads, we display both squads together and give the user a button to start the game, but we don't show the sum of each squad's points like we do during drafting. This isn't hard to add and would improve the view.

![Screen Shot 2023-07-29 at 1 42 06 PM](https://github.com/mina-arena/mina-arena/assets/8811423/956ac599-b5e9-4ca2-8607-21ce2542b97a)

## Solution

![Screen Shot 2023-07-29 at 1 42 14 PM](https://github.com/mina-arena/mina-arena/assets/8811423/5a46ece1-b314-4946-88a3-46039707430b)
