### PR TITLE
Fix action log showing unnecessary rolls

### DIFF
--- a/src/lib/components/sandbox/arena/ArenaActionLog.svelte
+++ b/src/lib/components/sandbox/arena/ArenaActionLog.svelte
@@ -192,18 +192,20 @@
 		attacks.forEach((attack) => {
 			if (attack.hitRoll.success) {
 				hitRollsPassed.push(attack.hitRoll.roll);
+				
+				if (attack.woundRoll.success) {
+					woundRollsPassed.push(attack.woundRoll.roll);
+
+					if (attack.saveRoll.success) {
+						saveRollsPassed.push(attack.saveRoll.roll);
+					} else {
+						saveRollsFailed.push(attack.saveRoll.roll);
+					}
+				} else {
+					woundRollsFailed.push(attack.woundRoll.roll);
+				}
 			} else {
 				hitRollsFailed.push(attack.hitRoll.roll);
-			}
-			if (attack.woundRoll.success) {
-				woundRollsPassed.push(attack.woundRoll.roll);
-			} else {
-				woundRollsFailed.push(attack.woundRoll.roll);
-			}
-			if (attack.saveRoll.success) {
-				saveRollsPassed.push(attack.saveRoll.roll);
-			} else {
-				saveRollsFailed.push(attack.saveRoll.roll);
 			}
 		});
 
@@ -283,18 +285,20 @@
 		attacks.forEach((attack) => {
 			if (attack.hitRoll.success) {
 				hitRollsPassed.push(attack.hitRoll.roll);
+
+				if (attack.woundRoll.success) {
+					woundRollsPassed.push(attack.woundRoll.roll);
+
+					if (attack.saveRoll.success) {
+						saveRollsPassed.push(attack.saveRoll.roll);
+					} else {
+						saveRollsFailed.push(attack.saveRoll.roll);
+					}
+				} else {
+					woundRollsFailed.push(attack.woundRoll.roll);
+				}
 			} else {
 				hitRollsFailed.push(attack.hitRoll.roll);
-			}
-			if (attack.woundRoll.success) {
-				woundRollsPassed.push(attack.woundRoll.roll);
-			} else {
-				woundRollsFailed.push(attack.woundRoll.roll);
-			}
-			if (attack.saveRoll.success) {
-				saveRollsPassed.push(attack.saveRoll.roll);
-			} else {
-				saveRollsFailed.push(attack.saveRoll.roll);
 			}
 		});
 


### PR DESCRIPTION
Prime @45930 

## Problem

If you fail your hit roll, the wound roll and save roll should never technically happen, and are not worth showing. Similarly, if you pass your hit roll but then fail your wound roll, the save roll should never technically happen.

The action log is currently showing all rolls regardless of whether a previous roll in the attack sequence failed (which should short circuit the attack sequence).

In the following example where `Judgement` is shooting at `Pointy`, only one of its two hit rolls passes. We should therefore only show the wound roll which followed the one successful hit roll. We should not show the wound roll which followed the failed hit roll.

![Screen Shot 2023-07-29 at 1 55 06 PM](https://github.com/mina-arena/mina-arena/assets/8811423/7ba8885f-984e-4af1-b016-796ab05630e0)

## Solution

Hide wound/save rolls which follow a failed previous roll in the attack sequence.

![Screen Shot 2023-07-29 at 1 54 50 PM](https://github.com/mina-arena/mina-arena/assets/8811423/e32373ca-bcc3-4591-9cf9-2eb972ac9802)
