### PR TITLE
Adjust tooltip unit cards

### DIFF
--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMelee.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMelee.svelte
@@ -24,21 +24,21 @@
 
 <div
 	id="piece-hover-tooltip"
-	class="hidden fixed max-w-[300px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
+	class="hidden fixed max-w-[500px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
 >
 	{#if hoveredPiece}
 		{@const owner = hoveredPiece.gamePlayer.player.minaPublicKey}
 		{@const hoveredUnit = hoveredPiece.playerUnit.unit}
 
-		<HoveredGamePieceTooltipUnitCard {hoveredPiece} />
+		<HoveredGamePieceTooltipUnitCard {hoveredPiece} {selectedPiece} />
 
 		{#if selectedPiece}
-			<div class="border-t border-black">
+			<div class="border-t border-black bg-stone-300 rounded-b-2xl">
 				{#if owner === currentPlayerMinaPubKey}
 					{#if selectedPiece.id === hoveredPiece.id}
-						<div class="text-center">Selected unit</div>
+						<div class="text-center p-1">Selected unit</div>
 					{:else}
-						<div class="text-center">Friendly unit</div>
+						<div class="text-center p-1">Friendly unit</div>
 					{/if}
 				{:else}
 					{@const attackDistance = distanceBetweenPoints(
@@ -46,7 +46,7 @@
 						hoveredPiece.coordinates
 					)}
 					{#if attackDistance > MELEE_ATTACK_RANGE}
-						<div class="text-center">Target out of range</div>
+						<div class="text-center p-1">Target out of range</div>
 					{:else}
 						{@const selectedUnit = selectedPiece.playerUnit.unit}
 						{@const estDamage = estimatedMeleeAttackDamage(selectedUnit, hoveredUnit)}

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMovement.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipMovement.svelte
@@ -15,9 +15,10 @@
 
 <div
 	id="piece-hover-tooltip"
-	class="hidden fixed max-w-[300px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
+	class="hidden fixed max-w-[500px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
 >
 	{#if hoveredPiece}
-		<HoveredGamePieceTooltipUnitCard {hoveredPiece} />
+		{@const selectedPiece = undefined}
+		<HoveredGamePieceTooltipUnitCard {hoveredPiece} {selectedPiece} />
 	{/if}
 </div>

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipShooting.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipShooting.svelte
@@ -20,21 +20,21 @@
 
 <div
 	id="piece-hover-tooltip"
-	class="hidden fixed max-w-[300px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
+	class="hidden fixed max-w-[500px] overflow-hidden p-4 rounded-2xl bg-stone-900 text-stone-700 drop-shadow-lg"
 >
 	{#if hoveredPiece}
 		{@const owner = hoveredPiece.gamePlayer.player.minaPublicKey}
 		{@const hoveredUnit = hoveredPiece.playerUnit.unit}
 
-		<HoveredGamePieceTooltipUnitCard {hoveredPiece} />
+		<HoveredGamePieceTooltipUnitCard {hoveredPiece} {selectedPiece} />
 
 		{#if selectedPiece}
-			<div class="border-t border-black">
+			<div class="border-t border-black bg-stone-300 rounded-b-2xl">
 				{#if owner === currentPlayerMinaPubKey}
 					{#if selectedPiece.id === hoveredPiece.id}
-						<div class="text-center">Selected unit</div>
+						<div class="text-center p-1">Selected unit</div>
 					{:else}
-						<div class="text-center">Friendly unit</div>
+						<div class="text-center p-1">Friendly unit</div>
 					{/if}
 				{:else}
 					{@const selectedUnit = selectedPiece.playerUnit.unit}
@@ -44,13 +44,13 @@
 					)}
 
 					{#if attackDistance > (selectedUnit.rangedRange || 0)}
-						<div class="text-center">Target out of range</div>
+						<div class="text-center p-1">Target out of range</div>
 					{:else}
 						{@const estDamage = estimatedRangedAttackDamage(selectedUnit, hoveredUnit)}
 						{@const estHealthAfter = Math.max(hoveredPiece.health - estDamage, 0)}
 
 						{#if !selectedUnit.rangedNumAttacks}
-							<div class="text-center">Selected unit has no ranged attack</div>
+							<div class="text-center p-1">Selected unit has no ranged attack</div>
 						{:else}
 							<div class="grid grid-cols-3 gap-4mx-auto">
 								<div class="col-span-2 border-r border-black p-[8px]">

--- a/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipUnitCard.svelte
+++ b/src/lib/components/sandbox/arena/tooltip/HoveredGamePieceTooltipUnitCard.svelte
@@ -2,61 +2,64 @@
   import { imagePathForUnit } from '$lib/utils';
 
   export let hoveredPiece: GamePiece;
+  export let selectedPiece: GamePiece | undefined;
 </script>
 
 {#if hoveredPiece}
   {@const hoveredUnit = hoveredPiece.playerUnit.unit}
   {@const unitImagePath = imagePathForUnit(hoveredUnit)}
-  <div class="col-span-1">
-    {#if unitImagePath}
-      <img class="rounded w-full" alt="Unit image" src={unitImagePath} width="200" height="200" />
-    {:else}
-      No image for unit
-    {/if}
-  </div>
-  <div class="font-almendra-bold uppercase bg-stone-300 p-2 mb-2 rounded text-center">
-    {hoveredPiece.playerUnit.name} ({hoveredUnit.name})
-  </div>
-  <div class="bg-stone-300 p-2 rounded flex-grow flex flex-col justify-center">
-    <table class="mx-auto">
-      <tr class="[&>*]:px-[4px] [&>*]:text-center">
-        <th><i class="fa-solid fa-person-running-fast"></i></th>
-        <th><i class="fa-solid fa-shield"></i></th>
-        <th><i class="fa-solid fa-heart"></i></th>
-      </tr>
-      <tr class="[&>*]:px-[4px] [&>*]:text-center">
-        <td>{hoveredUnit.movementSpeed}</td>
-        <td>{hoveredUnit.armorSaveRoll}+</td>
-        <td>{hoveredPiece.health}/{hoveredUnit.maxHealth}</td>
-      </tr>
-    </table>
-    <table class="mx-auto mt-[5px]">
-      <tr class="[&>*]:px-[4px] [&>*]:text-center">
-        <th></th>
-        <th><i class="fa-solid fa-hashtag"></i></th>
-        <th><i class="fa-solid fa-bullseye-arrow"></i></th>
-        <th><i class="fa-solid fa-hand-fist"></i></th>
-        <th><i class="fa-solid fa-shield-slash"></i></th>
-        <th><i class="fa-solid fa-heart-crack"></i></th>
-      </tr>
-      <tr class="[&>*]:px-[4px] [&>*]:text-center">
-        <td><i class="fa-solid fa-sword"></i></td>
-        <td>{hoveredUnit.meleeNumAttacks}</td>
-        <td>{hoveredUnit.meleeHitRoll}+</td>
-        <td>{hoveredUnit.meleeWoundRoll}+</td>
-        <td>{hoveredUnit.meleeArmorPiercing}</td>
-        <td>{hoveredUnit.meleeDamage}</td>
-      </tr>
-      {#if hoveredUnit.rangedNumAttacks}
-        <tr class="[&>*]:px-[4px] [&>*]:text-center">
-          <td><i class="fa-solid fa-bow-arrow"></i></td>
-          <td>{hoveredUnit.rangedNumAttacks}</td>
-          <td>{hoveredUnit.rangedHitRoll}+</td>
-          <td>{hoveredUnit.rangedWoundRoll}+</td>
-          <td>{hoveredUnit.rangedArmorPiercing}</td>
-          <td>{hoveredUnit.rangedDamage}</td>
-        </tr>
+  <div class="grid grid-cols-2">
+    <div class="col-span-1">
+      {#if unitImagePath}
+        <img class="w-full {selectedPiece ? 'rounded-tl-2xl' : 'rounded-l-2xl'}" alt="Unit image" src={unitImagePath} width="300" height="300" />
+      {:else}
+        No image for unit
       {/if}
-    </table>
+    </div>
+    <div class="bg-stone-300 p-2 col-span-1 {selectedPiece ? 'rounded-tr-2xl' : 'rounded-r-2xl'}">
+      <p class="font-almendra-bold uppercase text-center mb-[3px]">
+        {hoveredPiece.playerUnit.name} ({hoveredUnit.name})
+      </p>
+      <table class="mx-auto">
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <th><i class="fa-solid fa-person-running-fast"></i></th>
+          <th><i class="fa-solid fa-shield"></i></th>
+          <th><i class="fa-solid fa-heart"></i></th>
+        </tr>
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <td>{hoveredUnit.movementSpeed}</td>
+          <td>{hoveredUnit.armorSaveRoll}+</td>
+          <td>{hoveredPiece.health}/{hoveredUnit.maxHealth}</td>
+        </tr>
+      </table>
+      <table class="mx-auto mt-[5px]">
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <th></th>
+          <th><i class="fa-solid fa-hashtag"></i></th>
+          <th><i class="fa-solid fa-bullseye-arrow"></i></th>
+          <th><i class="fa-solid fa-hand-fist"></i></th>
+          <th><i class="fa-solid fa-shield-slash"></i></th>
+          <th><i class="fa-solid fa-heart-crack"></i></th>
+        </tr>
+        <tr class="[&>*]:px-[4px] [&>*]:text-center">
+          <td><i class="fa-solid fa-sword"></i></td>
+          <td>{hoveredUnit.meleeNumAttacks}</td>
+          <td>{hoveredUnit.meleeHitRoll}+</td>
+          <td>{hoveredUnit.meleeWoundRoll}+</td>
+          <td>{hoveredUnit.meleeArmorPiercing}</td>
+          <td>{hoveredUnit.meleeDamage}</td>
+        </tr>
+        {#if hoveredUnit.rangedNumAttacks}
+          <tr class="[&>*]:px-[4px] [&>*]:text-center">
+            <td><i class="fa-solid fa-bow-arrow"></i></td>
+            <td>{hoveredUnit.rangedNumAttacks}</td>
+            <td>{hoveredUnit.rangedHitRoll}+</td>
+            <td>{hoveredUnit.rangedWoundRoll}+</td>
+            <td>{hoveredUnit.rangedArmorPiercing}</td>
+            <td>{hoveredUnit.rangedDamage}</td>
+          </tr>
+        {/if}
+      </table>
+    </div>
   </div>
 {/if}


### PR DESCRIPTION
Prime @45930 

## Problem

Currently the hovered piece tooltip displays vertically, and doesn't display the proposed attack data correctly.

<img width="403" alt="Screen Shot 2023-07-29 at 6 42 31 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/fcec1502-6d7c-47d9-8fa6-c0d80fd16ed5">

## Solution

Display the card more horizontally and fix how the proposed attack is displayed.

<img width="895" alt="Screen Shot 2023-07-29 at 6 38 02 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/8caf937c-a952-4253-bcfc-f102684ff9a2">
<img width="914" alt="Screen Shot 2023-07-29 at 6 38 10 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/772b59ec-8e0f-49a9-a4f1-b6332ed00db4">
<img width="910" alt="Screen Shot 2023-07-29 at 6 38 30 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/9b32fc67-1695-402b-96b4-7be1f9614c3a">
<img width="910" alt="Screen Shot 2023-07-29 at 6 39 03 PM" src="https://github.com/mina-arena/mina-arena/assets/8811423/d1d9df09-b34a-4368-819d-ea58d026c381">
