### PR TITLE
Handle skipped attacks due to target already dead

### DIFF
--- a/src/lib/components/sandbox/arena/ArenaActionLog.svelte
+++ b/src/lib/components/sandbox/arena/ArenaActionLog.svelte
@@ -162,6 +162,8 @@
 				});
 			}
 			snarkyActionLogText += `Encrypted Dice Roll Input:<br/>${diceRolls}<br/><br/>`;
+
+			// Ignore skipped attacks (due to target already being dead)
 			if (a.actionData.resolvedAttack) attacks.push(a.actionData.resolvedAttack);
 		});
 		const attackingPiece = actions[0].gamePiece;
@@ -181,6 +183,11 @@
 		const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
 
 		text += `${attackingPieceTitle} shoots x${attacks.length} at ${targetPieceTitle}<br/>`;
+
+		if (attacks.length === 0) {
+			text += `${targetPieceTitle} is already destroyed, skipping attack.`
+			return [`${text}<br/><br/>`];
+		}
 
 		let hitRollsPassed: number[] = [];
 		let hitRollsFailed: number[] = [];
@@ -255,6 +262,8 @@
 				});
 			}
 			snarkyActionLogText += `Encrypted Dice Roll Input:<br/>${diceRolls}<br/><br/>`;
+
+			// Ignore skipped attacks (due to target already being dead)
 			if (a.actionData.resolvedAttack) attacks.push(a.actionData.resolvedAttack);
 		});
 		const attackingPiece = actions[0].gamePiece;
@@ -274,6 +283,11 @@
 		const targetPieceTitle = `<span style="color: ${targetPlayerColor}">${targetPlayerUnit.name} (${targetPlayerUnit.unit.name})</span>`;
 
 		text += `${attackingPieceTitle} strikes x${attacks.length} at ${targetPieceTitle}<br/>`;
+
+		if (attacks.length === 0) {
+			text += `${targetPieceTitle} is already destroyed, skipping attack.`
+			return [`${text}<br/><br/>`];
+		}
 
 		let hitRollsPassed: number[] = [];
 		let hitRollsFailed: number[] = [];


### PR DESCRIPTION
## Problem

If multiple attackers attack the same target, and the target is destroyed before the last attacker goes, then any attackers which are processed after the target is already dead will just have their attacks' `resolvedAttack` value be `null`.

Our action log code is expecting at least one of these attacks to have a `resolvedAttack`, which will not be the case in this scenario, resulting in an exception and the action log showing nothing.

## Solution

If a piece's attacks were all skipped (such as due to the target being dead) just display a simple message and don't try to show the rolls.

